### PR TITLE
Feat: 토큰 재발급 구현 (#48)

### DIFF
--- a/src/main/java/com/example/eightflix/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightflix/domain/auth/controller/AuthController.java
@@ -1,9 +1,11 @@
 package com.example.eightflix.domain.auth.controller;
 
+import com.example.eightflix.domain.auth.dto.ReissueResponse;
 import com.example.eightflix.domain.auth.dto.SignInRequest;
 import com.example.eightflix.domain.auth.dto.SignInResponse;
 import com.example.eightflix.domain.auth.dto.TokenPair;
 import com.example.eightflix.domain.auth.service.AuthService;
+import com.example.eightflix.global.security.CurrentUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -32,4 +34,16 @@ public class AuthController {
         response.addCookie(cookie);
         return ResponseEntity.ok(new SignInResponse(tokenPair.accessToken()));
     }
+
+    @PostMapping("/api/auth/reissue")
+    public ResponseEntity<ReissueResponse> reissue(@CurrentUser Long id, HttpServletResponse httpResponse) {
+        TokenPair tokenPair = authService.reissue(id);
+        Cookie cookie = new Cookie("refreshToken", tokenPair.refreshToken());
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(refreshTokenExpiration);
+        httpResponse.addCookie(cookie);
+        return ResponseEntity.ok(new ReissueResponse(tokenPair.accessToken()));
+    }
+
 }

--- a/src/main/java/com/example/eightflix/domain/auth/dto/ReissueResponse.java
+++ b/src/main/java/com/example/eightflix/domain/auth/dto/ReissueResponse.java
@@ -1,0 +1,6 @@
+package com.example.eightflix.domain.auth.dto;
+
+public record ReissueResponse (
+        String accessToken
+) {
+}

--- a/src/main/java/com/example/eightflix/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/eightflix/domain/auth/exception/AuthErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED,"토큰이 유효한 형태가 아닙니다.");
+    NOT_FOUND_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"액세스 토큰이 유효한 형태가 아닙니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"리프레시 토큰이 유효한 형태가 아닙니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/eightflix/domain/auth/repository/RedisTokenRepository.java
+++ b/src/main/java/com/example/eightflix/domain/auth/repository/RedisTokenRepository.java
@@ -26,4 +26,16 @@ public class RedisTokenRepository implements TokenRepository{
                 Duration.ofMillis(refreshTokenExpiration));
     }
 
+    @Override
+    public boolean isRefreshTokenValid(String id, String refreshToken) {
+        String key = "userId:" + id;
+        Object storedToken = redisTemplate.opsForValue().get(key);
+
+        return ("refreshToken:" + refreshToken).equals(String.valueOf(storedToken));
+    }
+
+    @Override
+    public void deleteRefreshToken(String id) {
+        redisTemplate.delete("userId:" + id);
+    }
 }

--- a/src/main/java/com/example/eightflix/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/example/eightflix/domain/auth/repository/TokenRepository.java
@@ -2,4 +2,6 @@ package com.example.eightflix.domain.auth.repository;
 
 public interface TokenRepository {
     void saveRefreshToken(String id, String refreshToken);
+    boolean isRefreshTokenValid(String id, String refreshToken);
+    void deleteRefreshToken(String id);
 }

--- a/src/main/java/com/example/eightflix/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/eightflix/domain/auth/service/AuthService.java
@@ -30,12 +30,21 @@ public class AuthService {
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new BizException(UserErrorCode.INVALID_PASSWORD);
         }
+        return getTokenPair(user);
+    }
 
+    private TokenPair getTokenPair(User user) {
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getNickname(), user.getRole());
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
         String refreshTokenSubString =  jwtUtil.substringToken(refreshToken);
-        tokenRepository.saveRefreshToken(user.getUserId(), refreshTokenSubString);
+        tokenRepository.saveRefreshToken(String.valueOf(user.getId()), refreshTokenSubString);
 
         return new TokenPair(accessToken, refreshTokenSubString);
+    }
+
+    public TokenPair reissue(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new BizException(UserErrorCode.NOT_FOUND_USER));
+        return getTokenPair(user);
     }
 }

--- a/src/main/java/com/example/eightflix/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/example/eightflix/domain/auth/util/JwtUtil.java
@@ -69,7 +69,7 @@ public class JwtUtil {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
         }
-        throw new BizException(AuthErrorCode.NOT_FOUND_TOKEN);
+        throw new BizException(AuthErrorCode.NOT_FOUND_ACCESS_TOKEN);
     }
 
     public Claims extractClaims(String token) {

--- a/src/main/java/com/example/eightflix/global/security/CustomAuthenticationToken.java
+++ b/src/main/java/com/example/eightflix/global/security/CustomAuthenticationToken.java
@@ -23,6 +23,16 @@ public class CustomAuthenticationToken extends AbstractAuthenticationToken {
         super.setAuthenticated(true); // 인증 완료로 설정
     }
 
+    public CustomAuthenticationToken(Object principal, Object credentials,
+                                     Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.email = null;
+        this.nickname = null;
+        super.setAuthenticated(true);
+    }
+
     @Override
     public Object getCredentials() {
         return credentials;

--- a/src/main/java/com/example/eightflix/global/security/JwtFilter.java
+++ b/src/main/java/com/example/eightflix/global/security/JwtFilter.java
@@ -30,8 +30,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest httpRequest, HttpServletResponse httpResponse, FilterChain filterChain) throws IOException, ServletException {
-
-        if (httpRequest.getRequestURI().startsWith("/api/auth")) {
+        if (SecurityUrlMatcher.isPublicUrl(httpRequest.getRequestURI()) ||
+                SecurityUrlMatcher.isRefreshUrl(httpRequest.getRequestURI())) {
             filterChain.doFilter(httpRequest, httpResponse);
             return;
         }

--- a/src/main/java/com/example/eightflix/global/security/RefreshTokenFilter.java
+++ b/src/main/java/com/example/eightflix/global/security/RefreshTokenFilter.java
@@ -1,0 +1,94 @@
+package com.example.eightflix.global.security;
+
+import com.example.eightflix.domain.auth.repository.TokenRepository;
+import com.example.eightflix.domain.auth.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !SecurityUrlMatcher.isRefreshUrl(request.getRequestURI());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            setErrorResponse(response, "RefreshToken 쿠키가 없습니다.");
+            return;
+        }
+
+        String refreshToken = null;
+        for (Cookie cookie : cookies) {
+            if ("refreshToken".equals(cookie.getName())) {
+                refreshToken = cookie.getValue();
+                break;
+            }
+        }
+
+        try {
+            Claims claims = jwtUtil.extractClaims(refreshToken);
+
+            if (claims == null) {
+                setErrorResponse(response, "유효하지 않은 RefreshToken입니다.");
+                return;
+            }
+
+            String userId = claims.getSubject();
+            if (!tokenRepository.isRefreshTokenValid(userId, refreshToken)) {
+                setErrorResponse(response, "유효하지 않은 RefreshToken입니다.");
+                return;
+            }
+
+            List<SimpleGrantedAuthority> authorities =
+                    List.of(new SimpleGrantedAuthority("ROLE_GUEST"));
+
+            CustomAuthenticationToken authentication =
+                    new CustomAuthenticationToken(userId, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, "토큰이 만료되었습니다.");
+        } catch (Exception e) {
+            setErrorResponse(response, "인증 과정에서 오류가 발생했습니다.");
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        String body = new ObjectMapper().writeValueAsString(
+                Map.of(
+                        "status", 401,
+                        "error", "Unauthorized",
+                        "message", message
+                )
+        );
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/com/example/eightflix/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/eightflix/global/security/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
 
 	private final JwtFilter jwtFilter;
 	private final CustomAccessDeniedHandler accessDeniedHandler;
+	private final RefreshTokenFilter refreshTokenFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
@@ -26,10 +27,12 @@ public class SecurityConfig {
 						.accessDeniedHandler(accessDeniedHandler)
 				)
 				.authorizeHttpRequests(auth -> auth
-						.requestMatchers("/api/auth/**").permitAll()
-						.requestMatchers("/api/admin/**").hasRole("ADMIN")
+						.requestMatchers(SecurityUrlMatcher.REFRESH_URL).authenticated()
+						.requestMatchers(SecurityUrlMatcher.PUBLIC_URLS).permitAll()
+						.requestMatchers(SecurityUrlMatcher.ADMIN_URLS).hasRole("ADMIN")
 						.anyRequest().authenticated()
 				)
+				.addFilterBefore(refreshTokenFilter, UsernamePasswordAuthenticationFilter.class)
 				.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/com/example/eightflix/global/security/SecurityUrlMatcher.java
+++ b/src/main/java/com/example/eightflix/global/security/SecurityUrlMatcher.java
@@ -1,0 +1,24 @@
+package com.example.eightflix.global.security;
+
+import java.util.Arrays;
+
+public class SecurityUrlMatcher {
+    public static final String[] PUBLIC_URLS = {
+            "/api/auth/signin",
+            "/api/auth/signup"
+    };
+
+    public static final String[] ADMIN_URLS = {
+            "/api/admin/**"
+    };
+
+    public static final String REFRESH_URL = "/api/auth/reissue";
+
+    public static boolean isRefreshUrl(String path) {
+        return REFRESH_URL.equals(path);
+    }
+
+    public static boolean isPublicUrl(String path) {
+        return Arrays.stream(PUBLIC_URLS).anyMatch(path::startsWith);
+    }
+}


### PR DESCRIPTION
## 작업내용
토큰 재발급을 구현했습니다.

## 변경사항
- ReissueFilter : 쿠키에 리프레시 토큰이 유효한지 검증합니다.
- AuthContoller: 토큰 재발급을 진행합닌다.

## 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->
/api/auth/reissue를 호출하면 accessToken과 refreshToken을 모두 재발급합니다.

## 체크 리스트
- [ ] 테스트 코드 작성
- [x] 포스트맨 확인