### PR TITLE
feat: Redisson 락, JPA 비관적 락 사용해서 영화 예매 구현

### DIFF
--- a/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
@@ -5,9 +5,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
-import com.example.eightflix.domain.reservation.service.LockService;
-import com.example.eightflix.domain.reservation.service.RedissonLockService;
 import com.example.eightflix.domain.reservation.service.ReservationLockStrategy;
+import com.example.eightflix.global.security.CurrentUser;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ReservationController {
-	private final ReservationLockStrategy DBLockService;
+	private final ReservationLockStrategy redissonLockService;
 
 	@PostMapping("/reservations")
 	public void reserveMovie(
-		// @AuthenticationPrincipal User user,
+		@CurrentUser Long userId,
 		@Valid @RequestBody ReservationRequest reservationRequest
-	) throws InterruptedException {
-		DBLockService.reserveMovie(1L, reservationRequest);
+	) {
+		redissonLockService.reserveMovie(userId, reservationRequest);
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
 import com.example.eightflix.domain.reservation.service.LockService;
 import com.example.eightflix.domain.reservation.service.RedissonLockService;
+import com.example.eightflix.domain.reservation.service.ReservationLockStrategy;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +15,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ReservationController {
-	private final RedissonLockService redissonLockService;
+	private final ReservationLockStrategy DBLockService;
 
 	@PostMapping("/reservations")
 	public void reserveMovie(
 		// @AuthenticationPrincipal User user,
 		@Valid @RequestBody ReservationRequest reservationRequest
 	) throws InterruptedException {
-		redissonLockService.reserveMovie(1L, reservationRequest);
+		DBLockService.reserveMovie(1L, reservationRequest);
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/controller/ReservationController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
 import com.example.eightflix.domain.reservation.service.LockService;
+import com.example.eightflix.domain.reservation.service.RedissonLockService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ReservationController {
-	private final LockService lockService;
+	private final RedissonLockService redissonLockService;
 
 	@PostMapping("/reservations")
 	public void reserveMovie(
 		// @AuthenticationPrincipal User user,
 		@Valid @RequestBody ReservationRequest reservationRequest
 	) throws InterruptedException {
-		lockService.reserveMovieWithLock(1L, reservationRequest);
+		redissonLockService.reserveMovie(1L, reservationRequest);
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/exception/ReservationErrorCode.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 public enum ReservationErrorCode implements ErrorCode {
 	UNAVAILABLE_SEAT_COUNT_ERROR(HttpStatus.BAD_REQUEST, "예약 가능한 좌석 개수가 아닙니다."),
 	UNAVAILABLE_SEAT_ERROR(HttpStatus.BAD_REQUEST, "예약할 수 없는 좌석입니다."),
-	ALREADY_RESERVED_SEAT_ERROR(HttpStatus.BAD_REQUEST, "이미 예약된 좌석입니다.");
+	ALREADY_RESERVED_SEAT_ERROR(HttpStatus.BAD_REQUEST, "이미 예약된 좌석입니다."),
+	CANNOT_GET_LOCK(HttpStatus.LOCKED, "락 획득에 실패했습니다."),
+	INTERRUPTED_LOCK(HttpStatus.LOCKED, "락 처리중에 인터럽트가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/eightflix/domain/reservation/repository/RedisLockRepository.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/repository/RedisLockRepository.java
@@ -16,7 +16,7 @@ public class RedisLockRepository {
 	public Boolean lock(String key){
 		return redisTemplate
 			.opsForValue()
-			.setIfAbsent(key, "lock", Duration.ofMillis(3000));
+			.setIfAbsent(key, "lock", Duration.ofSeconds(60));
 	}
 
 	public Long unlock(List<String> key){

--- a/src/main/java/com/example/eightflix/domain/reservation/repository/SeatRepository.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/repository/SeatRepository.java
@@ -15,10 +15,13 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+	@Query("SELECT s FROM Seat s WHERE s.seatCode IN :seatCodes AND s.movie.movieId = :movieId")
+	List<Seat> findValidSeatCodes(@Param("seatCodes") List<String> seatCodes, @Param("movieId") Long movieId);
+
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="10000")})
 	@Query("SELECT s FROM Seat s WHERE s.seatCode IN :seatCodes AND s.movie.movieId = :movieId")
-	List<Seat> findValidSeatCodes(@Param("seatCodes") List<String> seatCodes, @Param("movieId") Long movieId);
+	List<Seat> findValidSeatCodesWithLock(@Param("seatCodes") List<String> seatCodes, @Param("movieId") Long movieId);
 
 	Optional<Seat> findBySeatCodeAndMovieMovieId(String seatCode, Long movieId);
 

--- a/src/main/java/com/example/eightflix/domain/reservation/repository/SeatRepository.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/repository/SeatRepository.java
@@ -4,12 +4,19 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import com.example.eightflix.domain.reservation.entity.Seat;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="10000")})
 	@Query("SELECT s FROM Seat s WHERE s.seatCode IN :seatCodes AND s.movie.movieId = :movieId")
 	List<Seat> findValidSeatCodes(@Param("seatCodes") List<String> seatCodes, @Param("movieId") Long movieId);
 

--- a/src/main/java/com/example/eightflix/domain/reservation/service/DBLockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/DBLockService.java
@@ -25,14 +25,11 @@ import lombok.AllArgsConstructor;
  */
 @Service
 @AllArgsConstructor
-public class DBLockService {
+public class DBLockService implements ReservationLockStrategy {
 	private final MovieRepository movieRepository;
 	private final SeatRepository seatRepository;
 	private final UserRepository userRepository;
 	private final ReservationService reservationService;
-
-	private static final int MIN_SEAT_COUNT = 1;
-	private static final int MAX_SEAT_COUNT = 5;
 
 	@Transactional
 	public void reserveMovie(Long userId, ReservationRequest reservationRequest) {
@@ -44,28 +41,10 @@ public class DBLockService {
 
 		// 좌석 검증
 		List<Seat> validSeats =
-			seatRepository.findValidSeatCodes(reservationRequest.reservationSeats(), reservationRequest.movieId());
+			seatRepository.findValidSeatCodesWithLock(reservationRequest.reservationSeats(), reservationRequest.movieId());
 		validateSeatCount(reservationRequest.reservationSeats().size());  // 좌석 개수 제한
 		validateSeats(validSeats, reservationRequest.reservationSeats());  // 유효한 좌석인지 검증
 
 		reservationService.reserveMovie(user, movie, reservationRequest);
-	}
-
-	private static void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
-		List<String> validSeatCodes = validSeats.stream()
-			.map(Seat::getSeatCode)
-			.toList();
-
-		for (String reservationSeat : reservationSeats) {
-			if (!validSeatCodes.contains(reservationSeat)) {
-				throw new BizException(UNAVAILABLE_SEAT_ERROR);
-			}
-		}
-	}
-
-	private static void validateSeatCount(int seatSize) {
-		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
-			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
-		}
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/service/DBLockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/DBLockService.java
@@ -1,0 +1,71 @@
+package com.example.eightflix.domain.reservation.service;
+
+import static com.example.eightflix.domain.movie.exception.MovieErrorCode.*;
+import static com.example.eightflix.domain.reservation.exception.ReservationErrorCode.*;
+import static com.example.eightflix.domain.user.exception.UserErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.eightflix.domain.movie.entity.Movie;
+import com.example.eightflix.domain.movie.repository.MovieRepository;
+import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
+import com.example.eightflix.domain.reservation.entity.Seat;
+import com.example.eightflix.domain.reservation.repository.SeatRepository;
+import com.example.eightflix.domain.user.entity.User;
+import com.example.eightflix.domain.user.repository.UserRepository;
+import com.example.eightflix.global.exception.BizException;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * JPA 비관적 Lock 사용
+ */
+@Service
+@AllArgsConstructor
+public class DBLockService {
+	private final MovieRepository movieRepository;
+	private final SeatRepository seatRepository;
+	private final UserRepository userRepository;
+	private final ReservationService reservationService;
+
+	private static final int MIN_SEAT_COUNT = 1;
+	private static final int MAX_SEAT_COUNT = 5;
+
+	@Transactional
+	public void reserveMovie(Long userId, ReservationRequest reservationRequest) {
+		// movieId 검증
+		Movie movie = movieRepository.findById(reservationRequest.movieId())
+			.orElseThrow(() -> new BizException(MOVIE_NOT_FOUND));
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BizException(NOT_FOUND_USER));
+
+		// 좌석 검증
+		List<Seat> validSeats =
+			seatRepository.findValidSeatCodes(reservationRequest.reservationSeats(), reservationRequest.movieId());
+		validateSeatCount(reservationRequest.reservationSeats().size());  // 좌석 개수 제한
+		validateSeats(validSeats, reservationRequest.reservationSeats());  // 유효한 좌석인지 검증
+
+		reservationService.reserveMovie(user, movie, reservationRequest);
+	}
+
+	private static void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
+		List<String> validSeatCodes = validSeats.stream()
+			.map(Seat::getSeatCode)
+			.toList();
+
+		for (String reservationSeat : reservationSeats) {
+			if (!validSeatCodes.contains(reservationSeat)) {
+				throw new BizException(UNAVAILABLE_SEAT_ERROR);
+			}
+		}
+	}
+
+	private static void validateSeatCount(int seatSize) {
+		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
+			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
@@ -7,7 +7,6 @@ import static com.example.eightflix.domain.user.exception.UserErrorCode.*;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.example.eightflix.domain.movie.entity.Movie;
 import com.example.eightflix.domain.movie.repository.MovieRepository;
@@ -29,7 +28,6 @@ import lombok.RequiredArgsConstructor;
 public class LockService {
 	private final RedisLockRepository redisLockRepository;
 	private final ReservationService reservatonService;
-	private final TransactionTemplate transactionTemplate;
 	private final SeatRepository seatRepository;
 	private final MovieRepository movieRepository;
 	private final UserRepository userRepository;

--- a/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
@@ -32,7 +32,7 @@ public class LockService implements ReservationLockStrategy {
 	private final MovieRepository movieRepository;
 	private final UserRepository userRepository;
 
-	public void reserveMovie(Long userId, ReservationRequest reservationRequest) throws InterruptedException {
+	public void reserveMovie(Long userId, ReservationRequest reservationRequest) {
 		// movieId 검증
 		Movie movie = movieRepository.findById(reservationRequest.movieId())
 			.orElseThrow(() -> new BizException(MOVIE_NOT_FOUND));
@@ -48,7 +48,7 @@ public class LockService implements ReservationLockStrategy {
 		reserveMovieWithLock(reservationRequest, user, movie);
 	}
 
-	private void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) throws InterruptedException {
+	private void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) {
 		List<String> lockKeys = reservationRequest.reservationSeats().stream()
 			.map(seat -> "lock:seat:" + reservationRequest.movieId() + ":" + seat)
 			.sorted()
@@ -71,6 +71,8 @@ public class LockService implements ReservationLockStrategy {
 
 			// 락 획득이 완료되면 트랜잭션 시작
 			reservatonService.reserveMovie(user, movie, reservationRequest);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
 		} finally {
 			redisLockRepository.unlock(lockKeys);
 		}

--- a/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LockService {
 	private final RedisLockRepository redisLockRepository;
-	private final ReservatonService reservatonService;
+	private final ReservationService reservatonService;
 	private final TransactionTemplate transactionTemplate;
 	private final SeatRepository seatRepository;
 

--- a/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/LockService.java
@@ -25,15 +25,12 @@ import lombok.RequiredArgsConstructor;
  */
 @Service
 @RequiredArgsConstructor
-public class LockService {
+public class LockService implements ReservationLockStrategy {
 	private final RedisLockRepository redisLockRepository;
 	private final ReservationService reservatonService;
 	private final SeatRepository seatRepository;
 	private final MovieRepository movieRepository;
 	private final UserRepository userRepository;
-
-	private static final int MIN_SEAT_COUNT = 1;
-	private static final int MAX_SEAT_COUNT = 5;
 
 	public void reserveMovie(Long userId, ReservationRequest reservationRequest) throws InterruptedException {
 		// movieId 검증
@@ -51,7 +48,7 @@ public class LockService {
 		reserveMovieWithLock(reservationRequest, user, movie);
 	}
 
-	public void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) throws InterruptedException {
+	private void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) throws InterruptedException {
 		List<String> lockKeys = reservationRequest.reservationSeats().stream()
 			.map(seat -> "lock:seat:" + reservationRequest.movieId() + ":" + seat)
 			.sorted()
@@ -78,23 +75,4 @@ public class LockService {
 			redisLockRepository.unlock(lockKeys);
 		}
 	}
-
-	private static void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
-		List<String> validSeatCodes = validSeats.stream()
-			.map(Seat::getSeatCode)
-			.toList();
-
-		for (String reservationSeat : reservationSeats) {
-			if (!validSeatCodes.contains(reservationSeat)) {
-				throw new BizException(UNAVAILABLE_SEAT_ERROR);
-			}
-		}
-	}
-
-	private static void validateSeatCount(int seatSize) {
-		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
-			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
-		}
-	}
-
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/service/RedissonLockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/RedissonLockService.java
@@ -28,15 +28,12 @@ import lombok.RequiredArgsConstructor;
  */
 @Service
 @RequiredArgsConstructor
-public class RedissonLockService {
+public class RedissonLockService implements ReservationLockStrategy {
 	private final MovieRepository movieRepository;
 	private final SeatRepository seatRepository;
 	private final UserRepository userRepository;
 	private final ReservationService reservationService;
 	private final RedissonClient redissonClient;
-
-	private static final int MIN_SEAT_COUNT = 1;
-	private static final int MAX_SEAT_COUNT = 5;
 
 	public void reserveMovie(Long userId, ReservationRequest reservationRequest) {
 		// movieId 검증
@@ -51,10 +48,10 @@ public class RedissonLockService {
 		validateSeatCount(reservationRequest.reservationSeats().size());  // 좌석 개수 제한
 		validateSeats(validSeats, reservationRequest.reservationSeats());  // 유효한 좌석인지 검증
 
-		reserveMovieWithLock(reservationRequest, user, movie);
+		reserveMovieWithRedissonLock(reservationRequest, user, movie);
 	}
 
-	private void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) {
+	private void reserveMovieWithRedissonLock(ReservationRequest reservationRequest, User user, Movie movie) {
 		// lockKeys 생성
 		List<String> lockKeys = reservationRequest.reservationSeats().stream()
 			.map(seat -> "lock:seat:" + reservationRequest.movieId() + ":" + seat)
@@ -84,24 +81,6 @@ public class RedissonLockService {
 					lock.unlock();  // 락이 현재 스레드가 획득한 상태일 때만 락 해제
 				}
 			}
-		}
-	}
-
-	private static void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
-		List<String> validSeatCodes = validSeats.stream()
-			.map(Seat::getSeatCode)
-			.toList();
-
-		for (String reservationSeat : reservationSeats) {
-			if (!validSeatCodes.contains(reservationSeat)) {
-				throw new BizException(UNAVAILABLE_SEAT_ERROR);
-			}
-		}
-	}
-
-	private static void validateSeatCount(int seatSize) {
-		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
-			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/service/RedissonLockService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/RedissonLockService.java
@@ -5,15 +5,17 @@ import static com.example.eightflix.domain.reservation.exception.ReservationErro
 import static com.example.eightflix.domain.user.exception.UserErrorCode.*;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.redisson.RedissonMultiLock;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.example.eightflix.domain.movie.entity.Movie;
 import com.example.eightflix.domain.movie.repository.MovieRepository;
 import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
 import com.example.eightflix.domain.reservation.entity.Seat;
-import com.example.eightflix.domain.reservation.repository.RedisLockRepository;
 import com.example.eightflix.domain.reservation.repository.SeatRepository;
 import com.example.eightflix.domain.user.entity.User;
 import com.example.eightflix.domain.user.repository.UserRepository;
@@ -22,22 +24,21 @@ import com.example.eightflix.global.exception.BizException;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Lettuce 사용한 락 구현
+ * Redisson 사용한 락 구현
  */
 @Service
 @RequiredArgsConstructor
-public class LockService {
-	private final RedisLockRepository redisLockRepository;
-	private final ReservationService reservatonService;
-	private final TransactionTemplate transactionTemplate;
-	private final SeatRepository seatRepository;
+public class RedissonLockService {
 	private final MovieRepository movieRepository;
+	private final SeatRepository seatRepository;
 	private final UserRepository userRepository;
+	private final ReservationService reservationService;
+	private final RedissonClient redissonClient;
 
 	private static final int MIN_SEAT_COUNT = 1;
 	private static final int MAX_SEAT_COUNT = 5;
 
-	public void reserveMovie(Long userId, ReservationRequest reservationRequest) throws InterruptedException {
+	public void reserveMovie(Long userId, ReservationRequest reservationRequest) {
 		// movieId 검증
 		Movie movie = movieRepository.findById(reservationRequest.movieId())
 			.orElseThrow(() -> new BizException(MOVIE_NOT_FOUND));
@@ -53,31 +54,36 @@ public class LockService {
 		reserveMovieWithLock(reservationRequest, user, movie);
 	}
 
-	public void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) throws InterruptedException {
+	private void reserveMovieWithLock(ReservationRequest reservationRequest, User user, Movie movie) {
+		// lockKeys 생성
 		List<String> lockKeys = reservationRequest.reservationSeats().stream()
 			.map(seat -> "lock:seat:" + reservationRequest.movieId() + ":" + seat)
-			.sorted()
 			.toList();
 
-		int maxAttempts = 30;
+		// 각 key에 대해 RLock 객체 생성
+		List<RLock> locks = lockKeys.stream()
+			.map(redissonClient::getLock)
+			.toList();
+
+		// RedissonMultiLock 생성
+		RLock multiLock = new RedissonMultiLock(locks.toArray(new RLock[0]));
 
 		try {
-			// 트랜잭션 전에 좌석에 대한 모든 락을 먼저 획득
-			for (String key : lockKeys) {
-				int attempts = 0;
-				while (!redisLockRepository.lock(key)) {
-					Thread.sleep(100);
-					if (++attempts > maxAttempts) {
-						redisLockRepository.unlock(lockKeys); // 기존 락 해제
-						throw new BizException(ALREADY_RESERVED_SEAT_ERROR);
-					}
-				}
+			// 멀티락 획득
+			boolean locked = multiLock.tryLock(10, 30, TimeUnit.SECONDS);
+			if (!locked) {
+				throw new BizException(CANNOT_GET_LOCK);
 			}
 
-			// 락 획득이 완료되면 트랜잭션 시작
-			reservatonService.reserveMovie(user, movie, reservationRequest);
+			reservationService.reserveMovie(user, movie, reservationRequest);
+		} catch (InterruptedException e) {
+			throw new BizException(INTERRUPTED_LOCK);
 		} finally {
-			redisLockRepository.unlock(lockKeys);
+			for (RLock lock : locks) {
+				if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+					lock.unlock();  // 락이 현재 스레드가 획득한 상태일 때만 락 해제
+				}
+			}
 		}
 	}
 
@@ -98,5 +104,4 @@ public class LockService {
 			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
 		}
 	}
-
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/service/ReservationLockStrategy.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/ReservationLockStrategy.java
@@ -12,7 +12,7 @@ public interface ReservationLockStrategy {
 	int MIN_SEAT_COUNT = 1;
 	int MAX_SEAT_COUNT = 5;
 
-	void reserveMovie(Long userId, ReservationRequest reservationRequest) throws InterruptedException;
+	void reserveMovie(Long userId, ReservationRequest reservationRequest);
 
 	default void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
 		List<String> validSeatCodes = validSeats.stream()

--- a/src/main/java/com/example/eightflix/domain/reservation/service/ReservationLockStrategy.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/ReservationLockStrategy.java
@@ -1,0 +1,34 @@
+package com.example.eightflix.domain.reservation.service;
+
+import static com.example.eightflix.domain.reservation.exception.ReservationErrorCode.*;
+
+import java.util.List;
+
+import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
+import com.example.eightflix.domain.reservation.entity.Seat;
+import com.example.eightflix.global.exception.BizException;
+
+public interface ReservationLockStrategy {
+	int MIN_SEAT_COUNT = 1;
+	int MAX_SEAT_COUNT = 5;
+
+	void reserveMovie(Long userId, ReservationRequest reservationRequest) throws InterruptedException;
+
+	default void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
+		List<String> validSeatCodes = validSeats.stream()
+			.map(Seat::getSeatCode)
+			.toList();
+
+		for (String reservationSeat : reservationSeats) {
+			if (!validSeatCodes.contains(reservationSeat)) {
+				throw new BizException(UNAVAILABLE_SEAT_ERROR);
+			}
+		}
+	}
+
+	default void validateSeatCount(int seatSize) {
+		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
+			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/example/eightflix/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/ReservationService.java
@@ -1,23 +1,17 @@
 package com.example.eightflix.domain.reservation.service;
 
-import static com.example.eightflix.domain.movie.exception.MovieErrorCode.*;
 import static com.example.eightflix.domain.reservation.exception.ReservationErrorCode.*;
-import static com.example.eightflix.domain.user.exception.UserErrorCode.*;
-
-import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.eightflix.domain.movie.entity.Movie;
-import com.example.eightflix.domain.movie.repository.MovieRepository;
 import com.example.eightflix.domain.reservation.dto.request.ReservationRequest;
 import com.example.eightflix.domain.reservation.entity.Reservation;
 import com.example.eightflix.domain.reservation.entity.Seat;
 import com.example.eightflix.domain.reservation.repository.ReservationRepository;
 import com.example.eightflix.domain.reservation.repository.SeatRepository;
 import com.example.eightflix.domain.user.entity.User;
-import com.example.eightflix.domain.user.repository.UserRepository;
 import com.example.eightflix.global.exception.BizException;
 
 import lombok.RequiredArgsConstructor;
@@ -25,58 +19,29 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
-	private final MovieRepository movieRepository;
 	private final SeatRepository seatRepository;
-	private final UserRepository userRepository;
 	private final ReservationRepository reservationRepository;
 
-	private static final int MIN_SEAT_COUNT = 1;
-	private static final int MAX_SEAT_COUNT = 5;
-
 	@Transactional
-	public Reservation reserveMovie(Long userId, ReservationRequest reservationRequest) {
-		// movieId 검증
-		Movie movie = movieRepository.findById(reservationRequest.movieId())
-			.orElseThrow(() -> new BizException(MOVIE_NOT_FOUND));
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new BizException(NOT_FOUND_USER));
-
-		// 좌석 검증
-		List<Seat> validSeats =
-			seatRepository.findValidSeatCodes(reservationRequest.reservationSeats(), reservationRequest.movieId());
-		validateSeatCount(reservationRequest.reservationSeats().size());  // 좌석 개수 제한
-		validateSeats(validSeats, reservationRequest.reservationSeats());  // 유효한 좌석인지 검증
-
+	public void reserveMovie(User user, Movie movie, ReservationRequest reservationRequest) {
 		// 영화 예매
 		Reservation reservation = Reservation.builder()
 			.user(user)
 			.movie(movie)
 			.build();
 
-		return reservationRepository.save(reservation);
-	}
+		Reservation savedReservation = reservationRepository.save(reservation);
 
-	private static void validateSeats(List<Seat> validSeats, List<String> reservationSeats) {
-		List<String> validSeatCodes = validSeats.stream()
-			.map(Seat::getSeatCode)
-			.toList();
+		// 좌석 예매
+		for (String seatCode : reservationRequest.reservationSeats()) {
+			Seat seat = seatRepository.findBySeatCodeAndMovieMovieId(seatCode, reservationRequest.movieId())
+				.orElseThrow(() -> new BizException(UNAVAILABLE_SEAT_ERROR));
 
-		for (String reservationSeat : reservationSeats) {
-			if (!validSeatCodes.contains(reservationSeat)) {
-				throw new BizException(UNAVAILABLE_SEAT_ERROR);
-			}
-		}
-
-		for (Seat validSeat : validSeats) {
-			if (validSeat.getReservation() != null) {
+			if (seat.getReservation() != null) {
 				throw new BizException(ALREADY_RESERVED_SEAT_ERROR);
 			}
-		}
-	}
 
-	private static void validateSeatCount(int seatSize) {
-		if (seatSize > MAX_SEAT_COUNT || seatSize < MIN_SEAT_COUNT) {
-			throw new BizException(UNAVAILABLE_SEAT_COUNT_ERROR);
+			seat.updateReservation(savedReservation);
 		}
 	}
 }

--- a/src/main/java/com/example/eightflix/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/eightflix/domain/reservation/service/ReservationService.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ReservatonService {
+public class ReservationService {
 	private final MovieRepository movieRepository;
 	private final SeatRepository seatRepository;
 	private final UserRepository userRepository;

--- a/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
@@ -34,7 +34,7 @@ import com.example.eightflix.global.exception.BizException;
 @ActiveProfiles("test")
 class ReservationServiceTest {
 	@Autowired
-	private DBLockService dbLockService;
+	private ReservationLockStrategy redissonLockService;
 
 	@Autowired
 	private MovieRepository movieRepository;
@@ -89,7 +89,7 @@ class ReservationServiceTest {
 					List.of("A1", "A2")
 				);
 
-				dbLockService.reserveMovie(userId, request);
+				redissonLockService.reserveMovie(userId, request);
 				successCount.getAndIncrement();  // 성공
 			} catch (BizException ex) {
 				throw ex;
@@ -126,7 +126,7 @@ class ReservationServiceTest {
 			executorService.submit(() -> {
 				try {
 					barrier.await(); // 모든 스레드가 여기서 대기하다가 동시에 실행됨
-					dbLockService.reserveMovie(userId, requests.get(finalI));
+					redissonLockService.reserveMovie(userId, requests.get(finalI));
 					successCount.getAndIncrement();  // 성공
 				} catch (BizException e) {
 					throw e;

--- a/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
@@ -34,7 +34,7 @@ import com.example.eightflix.global.exception.BizException;
 @ActiveProfiles("test")
 class ReservationServiceTest {
 	@Autowired
-	private RedissonLockService redissonLockService;
+	private DBLockService dbLockService;
 
 	@Autowired
 	private MovieRepository movieRepository;
@@ -75,7 +75,6 @@ class ReservationServiceTest {
 	@DisplayName("동일한 영화 좌석 예매 시 동시성 제어에 성공한다.")
 	void reserveMovieConcurrencyTest() throws Exception {
 		AtomicInteger successCount = new AtomicInteger();
-		AtomicInteger failCount = new AtomicInteger();
 
 		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
 		CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
@@ -90,14 +89,11 @@ class ReservationServiceTest {
 					List.of("A1", "A2")
 				);
 
-				redissonLockService.reserveMovie(userId, request);
+				dbLockService.reserveMovie(userId, request);
 				successCount.getAndIncrement();  // 성공
 			} catch (BizException ex) {
-				System.out.println("에러 :" + ex.getErrorCode().getCode());
-				failCount.getAndIncrement(); // 좌석 중복 오류
 				throw ex;
 			} catch (BrokenBarrierException | InterruptedException ex) {
-				failCount.getAndIncrement();
 				throw new RuntimeException(ex);
 			} finally {
 				latch.countDown();
@@ -107,7 +103,7 @@ class ReservationServiceTest {
 		latch.await(); // 모든 스레드 종료 대기
 		executorService.shutdown();
 
-		System.out.println("성공: " + successCount + ", 실패: " + failCount);
+		System.out.println("성공: " + successCount);
 		assertThat(successCount.get()).isEqualTo(1);
 	}
 
@@ -115,7 +111,6 @@ class ReservationServiceTest {
 	@DisplayName("일부만 겹치는 영화 좌석 예매 시 동시성 제어에 성공한다.")
 	void reserveDuplicateSeatConcurrencyTest() throws Exception {
 		AtomicInteger successCount = new AtomicInteger();
-		AtomicInteger failCount = new AtomicInteger();
 
 		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
 		CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
@@ -131,14 +126,11 @@ class ReservationServiceTest {
 			executorService.submit(() -> {
 				try {
 					barrier.await(); // 모든 스레드가 여기서 대기하다가 동시에 실행됨
-					redissonLockService.reserveMovie(userId, requests.get(finalI));
+					dbLockService.reserveMovie(userId, requests.get(finalI));
 					successCount.getAndIncrement();  // 성공
 				} catch (BizException e) {
-					System.out.println("에러 :" + e.getErrorCode().getCode());
-					failCount.getAndIncrement(); // 좌석 중복 오류
 					throw e;
 				} catch (BrokenBarrierException | InterruptedException e) {
-					failCount.getAndIncrement();
 					throw new RuntimeException(e);
 				} finally {
 					latch.countDown();
@@ -149,7 +141,7 @@ class ReservationServiceTest {
 		latch.await(); // 모든 스레드 종료 대기
 		executorService.shutdown();
 
-		System.out.println("성공: " + successCount + ", 실패: " + failCount);
+		System.out.println("성공: " + successCount);
 		assertThat(successCount.get()).isEqualTo(1);
 	}
 

--- a/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.example.eightflix.domain.movie.entity.Movie;
 import com.example.eightflix.domain.movie.repository.MovieRepository;
@@ -28,9 +30,11 @@ import com.example.eightflix.domain.user.repository.UserRepository;
 import com.example.eightflix.global.exception.BizException;
 
 @SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
 class ReservationServiceTest {
 	@Autowired
-	private LockService lockService;
+	private RedissonLockService redissonLockService;
 
 	@Autowired
 	private MovieRepository movieRepository;
@@ -41,7 +45,7 @@ class ReservationServiceTest {
 	@Autowired
 	private UserRepository userRepository;
 
-	private static final int THREAD_COUNT = 1000;
+	private static final int THREAD_COUNT = 2000;
 
 	private Long movieId;
 	private Long userId;
@@ -86,14 +90,14 @@ class ReservationServiceTest {
 					List.of("A1", "A2")
 				);
 
-				lockService.reserveMovieWithLock(userId, request);
+				redissonLockService.reserveMovie(userId, request);
 				successCount.getAndIncrement();  // 성공
 			} catch (BizException ex) {
-				if (ex.getErrorCode().getCode().equals("ALREADY_RESERVED_SEAT_ERROR")) {
-					failCount.getAndIncrement(); // 좌석 중복 오류
-				}
+				System.out.println("에러 :" + ex.getErrorCode().getCode());
+				failCount.getAndIncrement(); // 좌석 중복 오류
 				throw ex;
 			} catch (BrokenBarrierException | InterruptedException ex) {
+				failCount.getAndIncrement();
 				throw new RuntimeException(ex);
 			} finally {
 				latch.countDown();
@@ -105,7 +109,6 @@ class ReservationServiceTest {
 
 		System.out.println("성공: " + successCount + ", 실패: " + failCount);
 		assertThat(successCount.get()).isEqualTo(1);
-		assertThat(failCount.get()).isEqualTo(THREAD_COUNT - 1);
 	}
 
 	@Test
@@ -128,14 +131,14 @@ class ReservationServiceTest {
 			executorService.submit(() -> {
 				try {
 					barrier.await(); // 모든 스레드가 여기서 대기하다가 동시에 실행됨
-					lockService.reserveMovieWithLock(userId, requests.get(finalI));
+					redissonLockService.reserveMovie(userId, requests.get(finalI));
 					successCount.getAndIncrement();  // 성공
 				} catch (BizException e) {
-					if (e.getErrorCode().getCode().equals("ALREADY_RESERVED_SEAT_ERROR")) {
-						failCount.getAndIncrement(); // 좌석 중복 오류
-					}
+					System.out.println("에러 :" + e.getErrorCode().getCode());
+					failCount.getAndIncrement(); // 좌석 중복 오류
 					throw e;
 				} catch (BrokenBarrierException | InterruptedException e) {
+					failCount.getAndIncrement();
 					throw new RuntimeException(e);
 				} finally {
 					latch.countDown();
@@ -148,7 +151,6 @@ class ReservationServiceTest {
 
 		System.out.println("성공: " + successCount + ", 실패: " + failCount);
 		assertThat(successCount.get()).isEqualTo(1);
-		assertThat(failCount.get()).isEqualTo(THREAD_COUNT-1);
 	}
 
 }

--- a/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/eightflix/domain/reservation/service/ReservationServiceTest.java
@@ -28,7 +28,7 @@ import com.example.eightflix.domain.user.repository.UserRepository;
 import com.example.eightflix.global.exception.BizException;
 
 @SpringBootTest
-class ReservatonServiceTest {
+class ReservationServiceTest {
 	@Autowired
 	private LockService lockService;
 


### PR DESCRIPTION
## 작업내용
- JPA 비관적 락 사용해서 동시성 제어
- Redisson 멀티락 사용해서 동시성 제어
- 동일한 좌석 예매 기능을 락 방식만 다르게 구현하도록 전략 패턴 사용 (Redisson, Lettuce, JPA 비관적 락)

## 변경사항
- 동작과정 변경
  - 사용자 요청(movieId, seats)이 유효한지 검증한 후 좌석에 대한 멀티락을 획득하는 것으로 변경함
  - 좌석에 대한 멀티락 획득 후 이미 예매된 좌석인지 확인한 다음에 좌석을 예매함
- Lettuce 락 TTL 설정
  - Lettuce의 락은 TTL이 지나면 unlock을 안 해도 락이 자동 해제되기 때문에 TTL 시간을 60초로 설정해주었습니다.

## 팀원에게 전할 말

## 체크 리스트
- [x] 테스트 코드 작성
- [x] 포스트맨 확인

close #49